### PR TITLE
Resolve GitHub API limit issues

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,14 @@ module ChsTech
     #
     # Returns a Octokit::Client Object
     def octokit
-      @octokit ||= Octokit::Client.new
+      @octokit ||= if ENV.include?("GH_TOKEN") && ENV.include?("GH_USER")
+                     Octokit::Client.new(
+                       :login        => ENV["GH_LOGIN"],
+                       :access_token => ENV["GH_TOKEN"],
+                     )
+                   else
+                     Octokit::Client.new
+                   end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,7 @@ module ChsTech
     #
     # Returns a Octokit::Client Object
     def octokit
-      @octokit ||= if ENV.include?("GH_TOKEN") && ENV.include?("GH_USER")
+      @octokit ||= if ENV.include?("GH_TOKEN") && ENV.include?("GH_LOGIN")
                      Octokit::Client.new(
                        :login        => ENV["GH_LOGIN"],
                        :access_token => ENV["GH_TOKEN"],


### PR DESCRIPTION
This uses the values in `GH_LOGIN` and `GH_TOKEN` if present to authenticate with the GitHub API. The change should resolve the problems seen with API limits causing build failures.

The values for the envvars are set on Travis, and are associated with a dummy account using a personal access token with no scopes set.
