### PR TITLE
People and company templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,29 +16,10 @@ At this point you're waiting on us. We like to at least comment on, if not accep
 
 ### Adding your name to the list of people
 
-Start by following the [contributing](#contributing) guide, then take a look in the [_people](https://github.com/charlestontechnology/charlestontechnology.github.io/tree/master/_people) directory of this repo. Create a new [markdown](https://guides.github.com/features/mastering-markdown/) file named after your Charleston Tech slack handle. The contents should look like this:
+Start by following the [contributing](#contributing) guide, then take a look in the [_people](https://github.com/charlestontechnology/charlestontechnology.github.io/tree/master/_people) directory of this repo.
 
-```
----
-name: Robert Colantuoni
-github: rgc
-twitter: rgc
-linkedin: robcolantuoni
-company: Limelight Networks
-title: Advanced Services Architect
----
-```
+Copy the [_template.md](https://github.com/charlestontechnology/charlestontechnology.github.io/tree/master/_people/_template.md) file to a new file named after your Charleston Tech slack handle, and update the information within.
 
-Add this file to your branch and send a PR so we can merge the change and add you to the list of amazing professionals and enthusiats in the Charleston tech community. :sunglasses:
+Add this file to your branch and send a PR so we can merge the change and add you to the list of amazing professionals and enthusiasts in the Charleston tech community. :sunglasses:
 
-For companies, we have the same process with slightly different fields, with the files located in _companies:
-
-```
----
-name: BoomTown!
-github: BoomTownROI
-twitter: BoomTownROI
-website: http://boomtownroi.com/
----
-```
-
+For companies, we have the same process with slightly different fields, with the files located in _companies.

--- a/_companies/_template.md
+++ b/_companies/_template.md
@@ -1,0 +1,8 @@
+---
+#required
+name: Company Name
+github: companyname
+#optional - remove if not using
+twitter: companyname
+website: http://companyname.com/
+---

--- a/_people/_template.md
+++ b/_people/_template.md
@@ -5,6 +5,6 @@ github: username
 #optional - remove if not using
 twitter: username
 linkedin: username
-company: Hireology
-title: Senior Manager of User Experience
+company: Company Name
+title: Your Title
 ---

--- a/_people/_template.md
+++ b/_people/_template.md
@@ -1,0 +1,10 @@
+---
+#required
+name: First Last
+github: username
+#optional - remove if not using
+twitter: username
+linkedin: username
+company: Hireology
+title: Senior Manager of User Experience
+---


### PR DESCRIPTION
This pull request creates template files for both the people and companies sections. Thanks to the underscore, these files do not create entries in those sections when viewing the website. Also updated the readme to reflect the new procedure.

Feel free to reject if you want to stick with the current way. Just thought this might be easier for less technical folks.
